### PR TITLE
Support zipped index folder (stdlib)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 0.2.0 (in development)
 
-* The NetCDF Kerchunk index can now also be Zip archive. 
+* The NetCDF Kerchunk index can now also be a Zip archive. 
   To use a Zip archive, pass an index path to the `nckcidx` CLI
   or to the `NcKcIndex`class whose filename has a `.zip`
   extension. [#8]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 0.2.0 (in development)
 
+* The NetCDF Kerchunk index can now also be Zip archive. 
+  To use a Zip archive, pass an index path to the `nckcidx` CLI
+  or to the `NcKcIndex`class whose filename has a `.zip`
+  extension. [#8]
 * Storage credentials and other text values in the JSON configuration 
   file of the NetCDF Kerchunk index can now contain template
   variables of the form `"$ENV"` or `"${ENV}"`. Such references 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Level-2 multi-level datasets.
 ## Index Format
 
 Consider some `<source-path>` that points into a NetCDF file archive.
-Then the path `<source-prefix>/<nc-path>/<nc-filename>.nc` points to a
+Then the path `<source-path>/<nc-path>/<nc-filename>.nc` points to a
 NetCDF file in the archive, where `<nc-path>` includes any sub-folders 
 between a `<source-path>` and the `<nc-filename>.nc`. 
 Typically, `<nc-path>` is or includes a substructure `<year>/<month>/<day>`. 

--- a/README.md
+++ b/README.md
@@ -9,42 +9,40 @@ Level-2 multi-level datasets.
 ## Index Format
 
 Consider some `<source-path>` that points into a NetCDF file archive.
-Then the path `<source-prefix>/<nc-path>/<nc-name>.nc` point to a
-NetCDF file.
+Then the path `<source-prefix>/<nc-path>/<nc-filename>.nc` points to a
+NetCDF file in the archive, where `<nc-path>` includes any sub-folders 
+between a `<source-path>` and the `<nc-filename>.nc`. 
+Typically, `<nc-path>` is or includes a substructure `<year>/<month>/<day>`. 
+Note that `<nc-path>` may also be empty.
 
-```
-  <source-path>/
-    <source-prefix>/<nc-path>/<nc-filename>.nc
-```
-
-The `<nc-path>` includes any sub-folders between a `<source-prefix>` and 
-the `<nc-filename>.nc`. Typically, `<nc-path>` is or includes a 
-substructure `<year>/<month>/<day>`. Note that `<nc-path>` may also
-be empty.
-
-The NetCDF Kerchunk Index is a folder (or Zip archive) `<index-path>`
-that has a corresponding structure to `<source-path>`: 
+The NetCDF Kerchunk Index at `<index-path>` takes the following form: 
 
 ```
   <index-path>/
     nckc-config.json
-    <index-prefix>/<nc-path>/<nc-filename>.nc.json
+    <nc-path>/<nc-filename>.nc.json
 ```
 
+where `<index-path>` points to a local directory or Zip archive.
+Zip archive filenames must use the extension `.zip`.
 The file `<index-path>/nckc-index.json` contains information 
-about the NetCDF file sources and provides a mapping from an
-`<index-prefix>` to its corresponding `<source-prefix>`:
+about the NetCDF file sources, for example:
 
 ```json
 {
-  "source_path": "<source-path>",
-  "source_protocol": "file",
-  "source_storage_options": {},
-  "prefixes": {
-    "<index-prefix>": "<source-prefix>"
-  } 
+  "source_path": "EODATA",
+  "source_protocol": "s3",
+  "source_storage_options": {
+    "endpoint_url": "https://s3.creodias.com",
+    "key": "${CREODIAS_S3_KEY}",
+    "secret": "${CREODIAS_S3_SECRET}"
+  }
 }
 ```
+
+where the value of `source_path` corresponds to `<source-path>` above.
+Textual values that contain the pattern `${NAME}` will be interpolated 
+by environment variables.
 
 
 ## Installation

--- a/tests/nckcindex/test_indexstore.py
+++ b/tests/nckcindex/test_indexstore.py
@@ -1,0 +1,100 @@
+import unittest
+from abc import ABC
+
+import pytest
+import os.path
+import shutil
+from xcube_smos.nckcindex import IndexStore
+
+local_path = os.path.dirname(__file__)
+index_dir_path = os.path.join(local_path, "test-index")
+index_zip_path = os.path.join(local_path, "test-index.zip")
+
+
+# noinspection PyUnresolvedReferences
+class IndexStoreTestMixin:
+
+    def test_new_x(self):
+        self.assertFalse(os.path.exists(self.path))
+        store = IndexStore.new(self.path, mode="x")
+        self.assertTrue(os.path.exists(self.path))
+        self.assertEqual(self.path, store.path)
+
+    def test_new_x_exist(self):
+        IndexStore.new(self.path, mode="x")
+        with pytest.raises(OSError, match=f"Index exists: "):
+            IndexStore.new(self.path, mode="x")
+
+    def test_new_x_replace(self):
+        IndexStore.new(self.path, mode="x")
+        IndexStore.new(self.path, mode="x", replace=True)
+
+    def test_list(self):
+        store = IndexStore.new(self.path, mode="x")
+        self._write_test_data(store)
+        store.close()
+        store = IndexStore.new(self.path, mode="r")
+        self.assertEqual({'README.md',
+                          'SMOS/SM/2022/05/07/data-07-1.nc.json',
+                          'SMOS/SM/2022/05/08/data-08-1.nc.json',
+                          'SMOS/SM/2022/05/08/data-08-2.nc.json',
+                          'SMOS/SM/2022/05/09/data-09-1.nc.json',
+                          'SMOS/SM/2022/05/09/data-09-2.nc.json',
+                          'SMOS/SM/2022/05/09/data-09-3.nc.json',
+                          'data/SMOS/SM/2022/05/07/data-07-1.nc',
+                          'data/SMOS/SM/2022/05/08/data-08-1.nc',
+                          'data/SMOS/SM/2022/05/08/data-08-2.nc',
+                          'data/SMOS/SM/2022/05/09/data-09-1.nc',
+                          'data/SMOS/SM/2022/05/09/data-09-2.nc',
+                          'data/SMOS/SM/2022/05/09/data-09-3.nc'},
+                         set(store.list()))
+
+    def test_list_with_prefix(self):
+        store = IndexStore.new(self.path, mode="x")
+        self._write_test_data(store)
+        store.close()
+        store = IndexStore.new(self.path, mode="r")
+        self.assertEqual({'SMOS/SM/2022/05/09/data-09-1.nc.json',
+                          'SMOS/SM/2022/05/09/data-09-2.nc.json',
+                          'SMOS/SM/2022/05/09/data-09-3.nc.json'},
+                         set(store.list(prefix='SMOS/SM/2022/05/09/')))
+
+    @staticmethod
+    def _write_test_data(store: IndexStore):
+        store.write("SMOS/SM/2022/05/07/data-07-1.nc.json", {})
+        store.write("SMOS/SM/2022/05/08/data-08-1.nc.json", {})
+        store.write("SMOS/SM/2022/05/08/data-08-2.nc.json", {})
+        store.write("SMOS/SM/2022/05/09/data-09-1.nc.json", {})
+        store.write("SMOS/SM/2022/05/09/data-09-2.nc.json", {})
+        store.write("SMOS/SM/2022/05/09/data-09-3.nc.json", {})
+        store.write("data/SMOS/SM/2022/05/07/data-07-1.nc", bytes([1, 2, 3]))
+        store.write("data/SMOS/SM/2022/05/08/data-08-1.nc", bytes([1, 2, 3]))
+        store.write("data/SMOS/SM/2022/05/08/data-08-2.nc", bytes([1, 2, 3]))
+        store.write("data/SMOS/SM/2022/05/09/data-09-1.nc", bytes([1, 2, 3]))
+        store.write("data/SMOS/SM/2022/05/09/data-09-2.nc", bytes([1, 2, 3]))
+        store.write("data/SMOS/SM/2022/05/09/data-09-3.nc", bytes([1, 2, 3]))
+        store.write("README.md", "# Hallo!")
+
+
+class DirIndexStoreTest(unittest.TestCase, IndexStoreTestMixin):
+
+    def setUp(self) -> None:
+        self.path = index_dir_path
+        shutil.rmtree(self.path, ignore_errors=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.path, ignore_errors=True)
+        self.path = None
+
+
+class ZipIndexStoreTest(unittest.TestCase, IndexStoreTestMixin):
+
+    def setUp(self) -> None:
+        self.path = index_zip_path
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.path):
+            os.remove(self.path)
+        self.path = None

--- a/tests/nckcindex/test_nckcindex.py
+++ b/tests/nckcindex/test_nckcindex.py
@@ -43,7 +43,7 @@ class NcKcIndexDirTest(unittest.TestCase):
                               source_path=source_path,
                               replace=True) as index:
             self.assert_local_index_ok(index)
-        with pytest.raises(OSError, match=f"Directory exists: *."):
+        with pytest.raises(OSError, match=f"Index exists: *."):
             NcKcIndex.create(index_path=index_path,
                              source_path=source_path,
                              replace=False)
@@ -59,7 +59,7 @@ class NcKcIndexDirTest(unittest.TestCase):
     # noinspection PyMethodMayBeStatic
     def test_open_not_found(self):
         with pytest.raises(FileNotFoundError,
-                           match=f"Directory not found: *."):
+                           match=f"Index not found: *."):
             NcKcIndex.open(index_path=index_path)
 
     def test_sync_dry_run(self):

--- a/tests/nckcindex/test_nckcindex.py
+++ b/tests/nckcindex/test_nckcindex.py
@@ -175,18 +175,17 @@ class NcKcIndexZipTest(unittest.TestCase):
         self.assertEqual(5, sync_count)
         self.assertEqual([], problems)
         with zipfile.ZipFile(index_zip_path) as zf:
-            self.assertEqual({"SM", INDEX_CONFIG_FILENAME},
-                             set(zf.namelist()))
-            # self.assertEqual([
-            #     f"SM_OPER_MIR_SMUDP2_{dt}_700_001_1.nc.json"
-            #     for dt in (
-            #         '20230401T150613_20230401T155931',
-            #         '20230401T155619_20230401T164933',
-            #         '20230401T173625_20230401T182938',
-            #         '20230401T191629_20230401T200942',
-            #         '20230401T205632_20230401T214947'
-            #     )
-            # ], zf.listdir(index_path + "/SM"))
+            self.assertEqual(
+                {
+                    INDEX_CONFIG_FILENAME,
+                    'SM/SM_OPER_MIR_SMUDP2_20230401T173625_20230401T182938_700_001_1.nc.json',
+                    'SM/SM_OPER_MIR_SMUDP2_20230401T205632_20230401T214947_700_001_1.nc.json',
+                    'SM/SM_OPER_MIR_SMUDP2_20230401T155619_20230401T164933_700_001_1.nc.json',
+                    'SM/SM_OPER_MIR_SMUDP2_20230401T150613_20230401T155931_700_001_1.nc.json',
+                    'SM/SM_OPER_MIR_SMUDP2_20230401T191629_20230401T200942_700_001_1.nc.json',
+                },
+                set(zf.namelist())
+            )
 
     def assert_local_index_ok(self, index):
         self.assertEqual(source_path, index.source_path)

--- a/tests/nckcindex/test_nckcindex.py
+++ b/tests/nckcindex/test_nckcindex.py
@@ -1,5 +1,7 @@
 import json
 import unittest
+import zipfile
+
 import fsspec
 import os.path
 import shutil
@@ -9,7 +11,7 @@ from xcube_smos.nckcindex import INDEX_CONFIG_FILENAME
 
 local_path = os.path.dirname(__file__)
 index_path = os.path.join(local_path, "test-index")
-index_config_path = os.path.join(index_path, INDEX_CONFIG_FILENAME)
+index_zip_path = os.path.join(local_path, "test-index.zip")
 
 source_path = os.path.realpath(
     os.path.join(local_path, "..", "..", "testdata")
@@ -61,24 +63,23 @@ class NcKcIndexTest(unittest.TestCase):
             )
         ], os.listdir(index_path + "/SM"))
 
-
     def assert_local_index_ok(self, index):
         self.assertEqual(source_path, index.source_path)
         self.assertEqual("file", index.source_protocol)
         self.assertEqual({}, index.source_storage_options)
         self.assertIsInstance(index.source_fs, fsspec.AbstractFileSystem)
         self.assertEqual(('file', 'local'), index.source_fs.protocol)
-        with open(index_config_path) as fp:
+        with open(os.path.join(index_path, INDEX_CONFIG_FILENAME)) as fp:
             config = json.load(fp)
-            self.assertEqual(
-                {
-                    'version': 2,
-                    'source_path': source_path,
-                    'source_protocol': 'file',
-                    'source_storage_options': {},
-                },
-                config
-            )
+        self.assertEqual(
+            {
+                'version': 2,
+                'source_path': source_path,
+                'source_protocol': 'file',
+                'source_storage_options': {},
+            },
+            config
+        )
 
     def test_open_with_env_subst(self):
         os.environ["TEST_KEY"] = "12345"
@@ -92,7 +93,7 @@ class NcKcIndexTest(unittest.TestCase):
             }
         }
         os.mkdir(index_path)
-        with open(index_config_path, "w") as f:
+        with open(os.path.join(index_path, INDEX_CONFIG_FILENAME), "w") as f:
             json.dump(config, f)
         index = NcKcIndex.open(index_path=index_path)
         self.assertEqual("s3://SMOS", index.source_path)
@@ -102,3 +103,75 @@ class NcKcIndexTest(unittest.TestCase):
             "key": "12345",
             "secret": "ABCDE",
         }, index.source_storage_options)
+
+
+class NcKcIndexZipTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        if os.path.exists(index_zip_path):
+            os.remove(index_zip_path)
+
+    def tearDown(self) -> None:
+        if os.path.exists(index_zip_path):
+            os.remove(index_zip_path)
+
+    def test_create(self):
+        index = NcKcIndex.create(index_path=index_zip_path,
+                                 source_path=source_path)
+        self.assertTrue(os.path.isfile(index_zip_path))
+        self.assert_local_index_ok(index)
+
+    def test_open(self):
+        NcKcIndex.create(index_path=index_zip_path,
+                         source_path=source_path)
+        index = NcKcIndex.open(index_path=index_zip_path)
+        self.assert_local_index_ok(index)
+
+    def test_sync_dry_run(self):
+        index = NcKcIndex.create(index_path=index_zip_path,
+                                 source_path=source_path)
+        sync_count, problems = index.sync("SM", dry_run=True)
+        self.assertEqual(5, sync_count)
+        self.assertEqual([], problems)
+        with zipfile.ZipFile(index_zip_path) as zf:
+            self.assertEqual([INDEX_CONFIG_FILENAME], zf.namelist())
+
+    def test_sync(self):
+        index = NcKcIndex.create(index_path=index_zip_path,
+                                 source_path=source_path)
+        sync_count, problems = index.sync("SM")
+        index.index_fs.close()
+        self.assertEqual(5, sync_count)
+        self.assertEqual([], problems)
+        with zipfile.ZipFile(index_zip_path) as zf:
+            self.assertEqual({"SM", INDEX_CONFIG_FILENAME},
+                             set(zf.namelist()))
+            self.assertEqual([
+                f"SM_OPER_MIR_SMUDP2_{dt}_700_001_1.nc.json"
+                for dt in (
+                    '20230401T150613_20230401T155931',
+                    '20230401T155619_20230401T164933',
+                    '20230401T173625_20230401T182938',
+                    '20230401T191629_20230401T200942',
+                    '20230401T205632_20230401T214947'
+                )
+            ], zf.listdir(index_path + "/SM"))
+
+    def assert_local_index_ok(self, index):
+        self.assertEqual(source_path, index.source_path)
+        self.assertEqual("file", index.source_protocol)
+        self.assertEqual({}, index.source_storage_options)
+        self.assertIsInstance(index.source_fs, fsspec.AbstractFileSystem)
+        self.assertEqual(('file', 'local'), index.source_fs.protocol)
+        with zipfile.ZipFile(index_zip_path, "r") as zf:
+            with zf.open(INDEX_CONFIG_FILENAME) as fp:
+                config = json.load(fp)
+        self.assertEqual(
+            {
+                'version': 2,
+                'source_path': source_path,
+                'source_protocol': 'file',
+                'source_storage_options': {},
+            },
+            config
+        )

--- a/xcube_smos/nckcindex/__init__.py
+++ b/xcube_smos/nckcindex/__init__.py
@@ -21,4 +21,5 @@
 
 from .constants import INDEX_CONFIG_FILENAME
 from .constants import INDEX_CONFIG_VERSION
+from .indexstore import IndexStore
 from .nckcindex import NcKcIndex

--- a/xcube_smos/nckcindex/cli.py
+++ b/xcube_smos/nckcindex/cli.py
@@ -3,7 +3,6 @@ import os
 
 import click
 
-
 S3_PROTOCOL = "s3"
 FILE_PROTOCOL = "file"
 
@@ -96,7 +95,7 @@ def create(ctx,
             "endpoint_url": s3_endpoint,
         }
         source_path = \
-            f"{source_path}/{s3_bucket}" if source_path and s3_bucket\
+            f"{source_path}/{s3_bucket}" if source_path and s3_bucket \
                 else source_path if source_path \
                 else s3_bucket
         source_storage_options = {k: v for k, v in s3_storage_options.items()
@@ -105,12 +104,12 @@ def create(ctx,
         source_storage_options = {}
     if not source_path:
         raise click.UsageError('Option --source must be given')
-    index = NcKcIndex.create(
-        index_path=index_path,
-        source_path=source_path,
-        source_storage_options=source_storage_options
-    )
-    print(f"Created empty index {os.path.abspath(index.index_path)}")
+    with NcKcIndex.create(
+            index_path=index_path,
+            source_path=source_path,
+            source_storage_options=source_storage_options
+    ) as index:
+        print(f"Created empty index {os.path.abspath(index.index_path)}")
 
 
 @cli.command()

--- a/xcube_smos/nckcindex/indexstore.py
+++ b/xcube_smos/nckcindex/indexstore.py
@@ -1,0 +1,185 @@
+import json
+import os
+import shutil
+from abc import ABC, abstractmethod
+import zipfile
+from typing import List, Optional
+
+
+class IndexStore(ABC):
+    """A file store used by the Kerchunk NetCDF index."""
+
+    @classmethod
+    def new(cls, path: str, mode: str = "r", replace: bool = False) \
+            -> 'IndexStore':
+        """Create a new index store instance for the given *path*
+        and *mode*.
+
+        :param path: The local store path. If the filename ends with ".zip"
+            a zip archive file is assumed, otherwise a directory.
+        :param mode: The store open mode. May be one of
+            "x" (create), "w" (write), "a" (append), or "r" (read-only).
+            Defaults to "r".
+        :param replace: If set and mode is "x"
+            an existing index store at *path* will be replaced by
+            a new and empty one.
+        :return: a new index store instance
+        """
+        if path.endswith(".zip"):
+            return ZipIndexStore(path, mode, replace=replace)
+        else:
+            return DirIndexStore(path, mode, replace=replace)
+
+    def __init__(self, path: str, mode: str):
+        """Internal constructor."""
+        if mode not in {"x", "a", "w", "r"}:
+            raise ValueError(f"Unknown mode {mode}")
+        self.path = os.path.realpath(path)
+        self.mode = mode
+
+    def __del__(self):
+        """Closes this store."""
+        self.close()
+
+    def close(self):
+        """Close this index store."""
+
+    @abstractmethod
+    def __contains__(self, file: str) -> bool:
+        """Check if given *file* exists in this store."""
+
+    @abstractmethod
+    def list(self, prefix: Optional[str] = None) -> List[str]:
+        """List the files in this store.
+        The method will return relative paths to files only.
+        The separator character is always a forward slash "/".
+        """
+
+    @abstractmethod
+    def open(self, file: str, mode: str = "r"):
+        """Open the given binary *file*.
+
+        :param file: The filename.
+        :param mode: The open mode. Must be either "w" or "r".
+        :return: a file pointer that can be used to write or read binary data
+        """
+
+    @abstractmethod
+    def write(self, file: str, data: str | dict | bytes):
+        """Write *data* to the given *file*.
+
+        :param file: The filename.
+        :param data: The data to write. A dictionary is converted
+            to JSON text. Text is converted to bytes using UTF-8 encoding.
+        """
+
+
+class DirIndexStore(IndexStore):
+    def __init__(self, path: str, mode: str, replace: bool = False):
+        super().__init__(path, mode)
+        dir_exists = os.path.exists(path)
+        if mode == "x":
+            if dir_exists:
+                if replace:
+                    shutil.rmtree(path)
+                    dir_exists = False
+                else:
+                    raise OSError(f"Index exists: {path}")
+            if not dir_exists:
+                os.makedirs(path, exist_ok=True)
+        elif not dir_exists:
+            raise FileNotFoundError(f"Index not found: {path}")
+
+    def __contains__(self, file: str) -> bool:
+        return os.path.exists(os.path.join(self.path, file))
+
+    def list(self, prefix: Optional[str] = None) -> List[str]:
+        files = []
+        n = len(self.path)
+        if prefix and prefix.endswith("/"):
+            root_path = os.path.join(self.path, prefix[:-1])
+            prefix = None
+        else:
+            root_path = self.path
+        if not os.path.isdir(root_path):
+            return []
+        for abs_path, _, _filenames in os.walk(root_path):
+            file_prefix = abs_path[n + 1:]
+            for filename in _filenames:
+                file = filename if not file_prefix \
+                    else f"{file_prefix}/{filename}"
+                if os.name == "nt":
+                    file = file.replace("\\", "/")
+                if not prefix or file.startswith(prefix):
+                    files.append(file)
+        return files
+
+    def open(self, file: str, mode: str = "r"):
+        if mode not in ("r", "w"):
+            raise ValueError("mode must be either 'r' or 'w")
+        path = os.path.join(self.path, file)
+        parent = os.path.dirname(path)
+        if not os.path.exists(parent):
+            os.makedirs(parent, exist_ok=True)
+        return open(os.path.join(self.path, file), mode=mode + "b")
+
+    def write(self, file: str, data: str | dict | bytes):
+        if isinstance(data, dict):
+            data = json.dumps(data)
+        if isinstance(data, str):
+            data = data.encode(encoding='utf-8')
+        with self.open(file, mode="w") as fp:
+            # noinspection PyTypeChecker
+            fp.write(data)
+
+
+class ZipIndexStore(IndexStore):
+    def __init__(self, path: str, mode: str, replace: bool = False):
+        super().__init__(path, mode)
+        self.zip_file = None
+        zip_exists = os.path.exists(path)
+        if mode == "x":
+            if zip_exists:
+                if replace:
+                    os.remove(path)
+                else:
+                    raise OSError(f"Index exists: {path}")
+            zip_file = zipfile.ZipFile(path, mode="x")
+            entries = []
+        else:
+            if not zip_exists:
+                raise FileNotFoundError(f"Index not found: {path}")
+            # noinspection PyTypeChecker
+            zip_file = zipfile.ZipFile(path, mode="r")
+            entries = zip_file.namelist()
+            if mode != "r":
+                zip_file.close()
+                # noinspection PyTypeChecker
+                zip_file = zipfile.ZipFile(path, mode=mode)
+        self.zip_file = zip_file
+        self.files = entries
+        self.file_set = set(entries)
+
+    def __contains__(self, file: str) -> bool:
+        return file in self.file_set
+
+    def list(self, prefix: Optional[str] = None) -> List[str]:
+        return [file for file in self.files
+                if not prefix or file.startswith(prefix)]
+
+    def open(self, file: str, mode: str = "r"):
+        # noinspection PyTypeChecker
+        return self.zip_file.open(file, mode=mode)
+
+    def write(self, file: str, data: str | dict | bytes):
+        if isinstance(data, dict):
+            data = json.dumps(data)
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        with self.open(file, mode="w") as fp:
+            fp.write(data)
+
+    def close(self):
+        if self.zip_file:
+            self.zip_file.close()
+            self.zip_file = None

--- a/xcube_smos/nckcindex/indexstore.py
+++ b/xcube_smos/nckcindex/indexstore.py
@@ -53,6 +53,11 @@ class IndexStore(ABC):
         """List the files in this store.
         The method will return relative paths to files only.
         The separator character is always a forward slash "/".
+        If *prefix* is given, it is used to filter files
+        that start with the given prefix string.
+
+        :param prefix: Optional prefix for filtering the returned files.
+        :return: The list of files in this store.
         """
 
     @abstractmethod

--- a/xcube_smos/nckcindex/nckcindex.py
+++ b/xcube_smos/nckcindex/nckcindex.py
@@ -20,11 +20,13 @@
 # DEALINGS IN THE SOFTWARE.
 
 import json
+import sys
 from pathlib import Path
 from typing import Union, Dict, Any, Optional, Iterator, List, \
     Tuple, TypeVar, Type
-import string
 import os
+import string
+import traceback
 import warnings
 
 import fsspec
@@ -95,8 +97,8 @@ class NcKcIndex:
             # noinspection PyBroadException
             try:
                 fs.close()
-            except BaseException:
-                pass
+            except BaseException as e:
+                traceback.print_exception(e, file=sys.stderr)
 
     @classmethod
     def create(

--- a/xcube_smos/nckcindex/nckcindex.py
+++ b/xcube_smos/nckcindex/nckcindex.py
@@ -20,16 +20,17 @@
 # DEALINGS IN THE SOFTWARE.
 
 import json
+import os
+import string
 import sys
+import traceback
+import warnings
 from pathlib import Path
 from typing import Union, Dict, Any, Optional, Iterator, List, \
     Tuple, TypeVar, Type
-import os
-import string
-import traceback
-import warnings
 
 import fsspec
+
 from .constants import INDEX_CONFIG_FILENAME
 from .constants import INDEX_CONFIG_VERSION
 from .indexstore import IndexStore
@@ -345,8 +346,8 @@ def _substitute_json(value: Any) -> Any:
     if isinstance(value, str):
         return _substitute_text(value)
     if isinstance(value, dict):
-        return {_substitute_text(k): _substitute_json(v) for k, v in
-                value.items()}
+        return {_substitute_text(k): _substitute_json(v)
+                for k, v in value.items()}
     if isinstance(value, list):
         return [_substitute_json(v) for v in value]
     return value

--- a/xcube_smos/nckcindex/nckcindex.py
+++ b/xcube_smos/nckcindex/nckcindex.py
@@ -148,7 +148,7 @@ class NcKcIndex:
         """Open the given index at *index_path*.
 
         :param index_path: The index path or URL.
-        :param mode: Open mode, must be either "w" or "r".
+        :param mode: Open mode, must be either "w", "a", or "r".
             Defaults to "r".
         :return: A NetCDF file index.
         """


### PR DESCRIPTION
The NetCDF Kerchunk index can now also be Zip archive. To use a Zip archive, pass an index path to the `nckcidx` CLI or to the `NcKcIndex`class whose filename has a `.zip` extension.

Closes #8